### PR TITLE
[Fix]: RefreshToken API 스펙에 맞춰서 변경 및 로그인 플로우 개선

### DIFF
--- a/Common/Sources/DataSources/Keychain/KeychainTokenStorage.swift
+++ b/Common/Sources/DataSources/Keychain/KeychainTokenStorage.swift
@@ -26,8 +26,6 @@ public final class KeychainTokenStorage: TokenStorage {
 
     if let refresh = refreshToken {
       try set(refresh, for: .refreshToken)
-    } else {
-      try delete(.refreshToken)
     }
   }
 

--- a/Infrastructure/Sources/NetworkImpl/AuthInterceptor.swift
+++ b/Infrastructure/Sources/NetworkImpl/AuthInterceptor.swift
@@ -97,14 +97,12 @@ public final class AuthInterceptor: RequestInterceptor {
   
   private func refreshTokens() async -> Bool {
     let tokens = tokenManager.load()
-    guard let accessToken = tokens.accessToken,
-          let refreshToken = tokens.refreshToken else {
+    guard let refreshToken = tokens.refreshToken else {
       return false
     }
     
     var header = [String : String]()
-    header[authorizationKey] = "Bearer \(accessToken)"
-    header[refreshTokenKey] = refreshToken
+    header[authorizationKey] = "Bearer \(refreshToken)"
     
     guard let request = try? TokenRefreshEndpoint(headers: header).createURLRequest() else {
       return false
@@ -131,6 +129,6 @@ public final class AuthInterceptor: RequestInterceptor {
   
 }
 
-extension NSNotification.Name {
+public extension NSNotification.Name {
   static let userDidLogout = NSNotification.Name("userDidLogout")
 }


### PR DESCRIPTION
## 어떤 작업을 했나요 ?

### API 명세 일치
1. AuthInterceptor 토큰 갱신 API 헤더 오류 -> 서버 Header 요구사항에 맞게 헤더 필드 변경 

### 로그인 플로우 개선
1. KeychainTokenStorage 토큰 삭제 로직 오류 수정
2. .userDidLogout 알림 추가